### PR TITLE
DTSPO-15909 - migrated Application Insights

### DIFF
--- a/pipeline/steps/tf-SharedInfra-variables.yaml
+++ b/pipeline/steps/tf-SharedInfra-variables.yaml
@@ -74,7 +74,7 @@ steps:
     displayName: Set policy file to key vault
     inputs:
       azureSubscription: ${{ parameters.subscriptionName }}
-      scriptType: 'pscore'
+      scriptType: 'bash'
       scriptLocation: 'inlineScript'
       inlineScript: |
         az keyvault secret set --name "HMI-APIM-BUILD-${{ upper(parameters.environment) }}-json" --file "$(secureFileVariable.secure_file_json_path)" --vault-name "hmi-shared-kv-${{ parameters.environment }}"

--- a/pipeline/variables/Shared.yaml
+++ b/pipeline/variables/Shared.yaml
@@ -13,7 +13,7 @@ variables:
   - name: containerName
     value: 'hmiapimterraform'
   - name: terraformVersion
-    value: '1.0.4'
+    value: '1.6.6'
   - template: ../../environments/${{ parameters.environment.name }}.yaml
   - group: HMI-APIM-BUILD-${{ upper(parameters.environment.name) }}
   - name: builtFrom

--- a/terraform/modules/app-insights/10-appinsights.tf
+++ b/terraform/modules/app-insights/10-appinsights.tf
@@ -1,8 +1,17 @@
-resource "azurerm_application_insights" "app_insights" {
-  name                = "${var.project}-appins-${var.environment}"
-  location            = var.location
+module "application_insights" {
+  source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
+
+  env      = var.env
+  product  = var.product
+  name     = "${var.project}-appins"
+  location = var.location
+
   resource_group_name = var.resource_group
-  tags                = var.tags
-  application_type    = "other"
-  retention_in_days   = var.environment == "sbox" || var.environment == "dev" || var.environment == "test" ? 30 : 60
+
+  common_tags = var.tags
+}
+
+moved {
+  from = azurerm_application_insights.app_insights
+  to   = module.application_insights.azurerm_application_insights.this
 }

--- a/terraform/modules/app-insights/10-appinsights.tf
+++ b/terraform/modules/app-insights/10-appinsights.tf
@@ -2,8 +2,8 @@ module "application_insights" {
   source = "git::https://github.com/hmcts/terraform-module-application-insights?ref=main"
 
 
-  env      = var.env
-  product  = var.product
+  env      = var.environment
+  product  = var.project
   name     = "${var.project}-appins"
   location = var.location
 

--- a/terraform/modules/app-insights/10-appinsights.tf
+++ b/terraform/modules/app-insights/10-appinsights.tf
@@ -2,11 +2,11 @@ module "application_insights" {
   source = "git::https://github.com/hmcts/terraform-module-application-insights?ref=main"
 
 
-  env      = var.environment
-  product  = var.project
-  name     = "${var.project}-appins"
-  location = var.location
-
+  env                 = var.environment
+  product             = var.project
+  name                = "${var.project}-appins"
+  location            = var.location
+  application_type    = "other"
   resource_group_name = var.resource_group
 
   common_tags = var.tags

--- a/terraform/modules/app-insights/10-appinsights.tf
+++ b/terraform/modules/app-insights/10-appinsights.tf
@@ -1,5 +1,6 @@
 module "application_insights" {
-  source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
+  source = "git::https://github.com/hmcts/terraform-module-application-insights?ref=main"
+
 
   env      = var.env
   product  = var.product

--- a/terraform/modules/app-insights/12-ping-tests.tf
+++ b/terraform/modules/app-insights/12-ping-tests.tf
@@ -4,7 +4,7 @@ resource "azurerm_template_deployment" "web-test" {
   deployment_mode     = "Incremental"
   count               = length(var.ping_tests)
   parameters = {
-    appInsightsName = azurerm_application_insights.app_insights.name
+    appInsightsName = module.application_insights.name
     pingTestName    = "${lookup(var.ping_tests[count.index], "pingTestName")}-${var.environment}"
     pingTestURL     = lookup(var.ping_tests[count.index], "pingTestURL")
     pingText        = lookup(var.ping_tests[count.index], "pingText")

--- a/terraform/modules/app-insights/90-outputs.tf
+++ b/terraform/modules/app-insights/90-outputs.tf
@@ -1,11 +1,11 @@
 output "instrumentation_key" {
-  value = azurerm_application_insights.app_insights.instrumentation_key
+  value = module.application_insights.instrumentation_key
 }
 
 output "app_id" {
-  value = azurerm_application_insights.app_insights.app_id
+  value = module.application_insights.app_id
 }
 
 output "id" {
-  value = azurerm_application_insights.app_insights.id
+  value = module.application_insights.id
 }

--- a/terraform/modules/storage-account/main.tf
+++ b/terraform/modules/storage-account/main.tf
@@ -13,7 +13,7 @@ module "sa" {
   account_replication_type = var.sa_account_replication_type
   access_tier              = var.sa_access_tier
 
-  team_name    = "HMI DevOps"
+
   team_contact = "#vh-devops"
 
   common_tags = var.common_tags


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15909

### Change description ###
Updating azurerm_application_insights resource and replacing it with module terraform-module-application-insights

This will allow us to migrate Classic Application Insights using https://github.com/hmcts/app-insights-migration-tool as Classic Application Insights will deprecated and will be retired in February 2024.